### PR TITLE
fix: use ctrl in key bindings

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -122,8 +122,8 @@ export default () => {
 
   useKeyBindings({
     Escape: { fn: hideOverlay },
-    KeyI: { fn: showOverlay(OVERLAY_STATE.INFO) },
-    KeyT: { fn: changeTheme },
+    KeyI: { ctrl: true, fn: showOverlay(OVERLAY_STATE.INFO) },
+    KeyT: { ctrl: true, fn: changeTheme },
     KeyS: { ctrl: true, fn: showOverlay(OVERLAY_STATE.PREVIEW) }
   })
 


### PR DESCRIPTION
This PR fixes a problem where the keybindings stopped you from writing some letters in the playground.