### PR TITLE
fix: check ResizeObserver availability before use

### DIFF
--- a/packages/app/src/components/app-frame.js
+++ b/packages/app/src/components/app-frame.js
@@ -5,14 +5,9 @@ export const AppFrame = ({ sx, ...props }) => {
     <Flex
       sx={{
         bg: 'white',
-        height: '100vh',
+        height: ['initial', '', '100vh'],
         flexDirection: ['column', '', 'row'],
-        position: 'fixed',
-        left: 0,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        overflow: ['scroll', '', 'hidden'],
+        overflow: ['initial', '', 'hidden'],
         ...sx
       }}
       {...props}

--- a/packages/app/src/containers/preview-area.js
+++ b/packages/app/src/containers/preview-area.js
@@ -120,7 +120,6 @@ export const PreviewArea = ({ isEditor }) => {
             sx={{
               alignItems: 'center',
               position: 'absolute',
-              width: '100%',
               left: 3,
               top: 3
             }}

--- a/packages/app/src/pages/_app.js
+++ b/packages/app/src/pages/_app.js
@@ -37,7 +37,8 @@ const meta = {
 
 export default class App extends NextApp {
   render () {
-    const { Component, pageProps } = this.props
+    const { Component, pageProps, router } = this.props
+    const isEditor = router.asPath.startsWith('/editor')
 
     return (
       <ThemeProvider theme={theme}>
@@ -151,6 +152,13 @@ export default class App extends NextApp {
         <AppContextProvider>
           <Component {...pageProps} />
         </AppContextProvider>
+
+        {isEditor && (
+          <script
+            crossOrigin='anonymous'
+            src='https://polyfill.io/v3/polyfill.min.js?features=ResizeObserver'
+          />
+        )}
       </ThemeProvider>
     )
   }

--- a/packages/app/src/theme.js
+++ b/packages/app/src/theme.js
@@ -48,7 +48,7 @@ export const theme = {
       fontFamily: 'sans',
       lineHeight: 1.5,
       margin: 0,
-      overflow: 'hidden'
+      overflow: ['initial', '', 'hidden']
     }
   }
 }


### PR DESCRIPTION
+ Fix app crashing on devices that don't support `ResizeObserver` (eg. < iOS 13.4)