### PR TITLE
fix: download button click

### DIFF
--- a/packages/app/src/containers/preview-area.js
+++ b/packages/app/src/containers/preview-area.js
@@ -64,8 +64,8 @@ const PreviewScaler = ({ mainRef, ...props }) => {
 
 export const PreviewArea = ({ isEditor }) => {
   const {
+    downloadScreenshot,
     showOverlay,
-    screenshotUrl,
     theme: { bg, color }
   } = useContext(AppContext)
 
@@ -74,6 +74,7 @@ export const PreviewArea = ({ isEditor }) => {
   const PreviewWrap = useMemo(() => (isEditor ? PreviewScaler : Fragment), [
     isEditor
   ])
+
   const wrapProps = useMemo(() => (isEditor ? { mainRef } : {}), [
     isEditor,
     mainRef
@@ -173,12 +174,7 @@ export const PreviewArea = ({ isEditor }) => {
             <InternalLink
               href='#'
               sx={{ color }}
-              onClick={() => {
-                const link = document.createElement('a')
-                link.download = Date.now()
-                link.href = screenshotUrl
-                window.open(link)
-              }}
+              onClick={downloadScreenshot}
             >
               Download
             </InternalLink>

--- a/packages/app/src/context/index.js
+++ b/packages/app/src/context/index.js
@@ -25,7 +25,7 @@ export default function AppContextProvider ({ children }) {
     setQueryVariables
   } = editorContext(presetRef, query, setQuery)
 
-  const [screenshotUrl, syncScreenshotUrl] = useScreenshotUrl(queryVariables)
+  const [screenshotUrl, syncScreenshotUrl, downloadScreenshot] = useScreenshotUrl(queryVariables)
 
   const onOverlayShow = useCallback(() => syncScreenshotUrl(queryVariables), [
     queryVariables,
@@ -53,6 +53,7 @@ export default function AppContextProvider ({ children }) {
       changeTheme,
       code,
       colorMode,
+      downloadScreenshot,
       handleCode,
       handlePresetChange,
       handleQueryVariables,
@@ -70,6 +71,7 @@ export default function AppContextProvider ({ children }) {
       changeTheme,
       code,
       colorMode,
+      downloadScreenshot,
       handleCode,
       handlePresetChange,
       handleQueryVariables,

--- a/packages/app/src/hooks/use-screenshot-url.js
+++ b/packages/app/src/hooks/use-screenshot-url.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 
 import { getScreenshotUrl, isDev } from '@/lib'
 
@@ -31,10 +31,28 @@ const getCardUrl = ({ endpoint, ...props }) => {
 
 export const useScreenshotUrl = queryVariables => {
   const [screenshotUrl, setScreenshotUrl] = useState('')
+  const [runDownload, setRunDownload] = useState(false)
 
-  const sync = queryVariables => setScreenshotUrl(getCardUrl(queryVariables))
+  const sync = useCallback(queryVariables => setScreenshotUrl(getCardUrl(queryVariables)), [])
 
-  useEffect(() => sync(queryVariables), [])
+  const downloadScreenshot = useCallback(() => {
+    sync(queryVariables)
+    setRunDownload(true)
+  }, [queryVariables, sync])
 
-  return [screenshotUrl, sync]
+  useEffect(() => sync(queryVariables), [sync])
+
+  useEffect(() => {
+    if (runDownload) {
+      setRunDownload(false)
+
+      const link = document.createElement('a')
+      link.download = Date.now()
+      link.href = screenshotUrl
+
+      window.open(link)
+    }
+  }, [runDownload, screenshotUrl])
+
+  return [screenshotUrl, sync, downloadScreenshot]
 }


### PR DESCRIPTION
closes #72 

+ Move logic for downloading a screenshot to `useScreenshotUrl` hook