### PR TITLE
fix: improve layout for short titles in SMHutch preset

### DIFF
--- a/packages/app/src/components/presets/smhutch.js
+++ b/packages/app/src/components/presets/smhutch.js
@@ -22,7 +22,8 @@ const code = (
         sx={{
           alignItems: 'flex-end',
           justifyContent: 'space-between',
-          height: '100%'
+          height: '100%',
+          width: '100%'
         }}
       >
         <Flex


### PR DESCRIPTION
Fix a layout issue when using a short `title`. By setting width to 100%, the logo is always pushed to the far right side.