### PR TITLE
fix(ckgrafico): use image component for images

### DIFF
--- a/packages/app/src/components/presets/ckgrafico.js
+++ b/packages/app/src/components/presets/ckgrafico.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 import Inline from '../inline.macro'
-import { Box, Avatar, Flex, Link, Paragraph, Text } from './scope'
+import { Box, Avatar, Flex, Link, Paragraph, Text, Image } from './scope'
 
 const code = (
   <Inline>
@@ -76,15 +76,14 @@ const code = (
             </Text>
           )}
         </Box>
-        <Box
+        <Image
           sx={{
-            height: '50%',
-            width: '65%',
-            backgroundImage: `url(${query.thumbnail})`,
-            backgroundSize: 'cover',
-            position: 'absolute',
-            bottom: '-10%'
+            bottom: '-15%',
+            height: '55%',
+            objectFit: 'contain',
+            position: 'absolute'
           }}
+          src={query.thumbnail}
         />
       </Flex>
     </>


### PR DESCRIPTION
trying to avoid this

![download](https://user-images.githubusercontent.com/2096101/113288157-dc403800-92ee-11eb-85f7-44e30ee5810a.png)

using a real `img` html component
