### PR TITLE
Fix default preset

### DIFF
--- a/packages/app/src/context/index.js
+++ b/packages/app/src/context/index.js
@@ -12,10 +12,12 @@ import themeContext from './theme-context'
 
 export const AppContext = createContext({})
 
+const getDefaultPreset = slug => getPresetBySlug(presets, slug) || getPresetBySlug(presets, DEFAULT_PRESET)
+
 export default function AppContextProvider ({ children }) {
   const [query, setQuery] = useQueryState()
 
-  const presetRef = useRef(getPresetBySlug(presets, query?.preset ?? DEFAULT_PRESET) || presets[DEFAULT_PRESET])
+  const presetRef = useRef(getDefaultPreset(query?.preset ?? DEFAULT_PRESET))
 
   const {
     code,


### PR DESCRIPTION
@Kikobeats just spotted that since `DEFAULT_PRESET` is now a slug, the `presets[DEFAULT_PRESET]` lookup doesn't give the expected result (as the default would need to be in camelCase), and this throws an error in our context. You can replicate going to to a URL like https://cards.microlink.io/editor?preset=wot

I like the idea of `DEFAULT_PRESET` being a slug, so rather than changing it to `appleAccessibility`, this fix brings back the "old logic". Where if the provided `preset` doesn't exist, we render the default preset.

However, I think it'd be nice to also update the `?preset` parameter on the page URL too. I played about with it but couldn't get it working as I'd like (I tried using `handlePresetChange` in a `useEffect` that only ran when the `?preset` wasn't found, the URL updates for a moment, but then changes back to the original query).

Want to take a stab at it?