### PR TITLE
fix: missing `twitter` preset data

### DIFF
--- a/packages/app/src/components/presets/twitter.js
+++ b/packages/app/src/components/presets/twitter.js
@@ -36,11 +36,12 @@ const code = (
                 selector: 'a[href*="likes"]',
                 attr: 'text'
               },
-              date: {
+              tweetDate: {
                 selector: 'div [dir="auto"] a[href*="status"] span',
                 type: 'text'
               }
-            }
+            },
+            waitForSelector: 'div [dir="auto"] a[href*="status"] span'
           }}
         >
           {payload => {
@@ -136,7 +137,7 @@ const code = (
                   >
                     {data.retweets} {data.likes}
                     {data.retweets && data.likes ? ' · ' : ''}
-                    {data.date.replace('·', '')}
+                    {data.tweetDate.replace('·', '')}
                   </Text>
                 </Flex>
               </Flex>


### PR DESCRIPTION
Not sure if you'd noticed @Kikobeats but some of the data isn't showing for the [Twitter preset](https://cards.microlink.io/editor?preset=twitter).