### PR TITLE
refactor: use lz-string insteadof msgpack+base64

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,8 +40,8 @@
     "cycled": "~2.0.0",
     "deep-object-diff": "~1.1.0",
     "framer-motion": "~6.2.1",
+    "lz-string": "~1.4.4",
     "monaco-themes": "~0.4.0",
-    "msgpack5": "~5.3.2",
     "next": "12.0.10",
     "next-transpile-modules": "~9.0.0",
     "polished": "~4.1.3",
@@ -55,8 +55,7 @@
     "styled-components": "~5.3.3",
     "theme-ui": "~0.13.1",
     "throttle-debounce": "~3.0.1",
-    "tickedoff": "~1.0.2",
-    "urlsafe-base64": "~1.0.0"
+    "tickedoff": "~1.0.2"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "latest",

--- a/packages/app/src/lib/compress-json.js
+++ b/packages/app/src/lib/compress-json.js
@@ -1,8 +1,6 @@
-import createMsgpack from 'msgpack5'
-import URLSafeBase64 from 'urlsafe-base64'
+import LZString from 'lz-string'
 
-const msgpack = createMsgpack()
+export const marshall = value => LZString.compressToEncodedURIComponent(value)
 
-export const marshall = value => URLSafeBase64.encode(msgpack.encode(value))
-
-export const unmarshall = value => msgpack.decode(URLSafeBase64.decode(value))
+export const unmarshall = value =>
+  LZString.decompressFromEncodedURIComponent(value)


### PR DESCRIPTION
![CleanShot 2022-02-14 at 17 35 54@2x](https://user-images.githubusercontent.com/2096101/153915605-86f8c596-cc2c-4a9d-9da4-9ba05377f124.png)

I noted https://prettier.io/playground is using `lz-string` for creating a string representation of the code.

After [read](https://pieroxy.net/blog/pages/lz-string/index.html) about it, it fits better the Microlink Cards use case (that's similar to prettier playground).

That's because the current approach is using  mspack that produces binary data, and we are encoding that data using base64.

That's smaller to JSON, but `lz-string` is smaller than the current output, in less steps Plus, the dependency is smaller (~15KB vs ~1.4KB), making the site load faster as well.

Unfortunately, this is a breaking change for people that are interacting with Microlink Cards without using a preset.

The good news is, we shipped a lot of presets recently and also a contribution guide for adding your own preset, so eventually if you are affected by this, you can integrate your preset, and you will not experiment the problem anymore.
