### PR TITLE
feat(types): add TypeScript type definitions

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://github.com/microlinkhq/cards/tree/master/packages/npm",
   "version": "1.13.81",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "author": {
     "email": "hello@microlink.io",
     "name": "microlink.io",
@@ -46,7 +47,8 @@
     "node": ">= 10"
   },
   "files": [
-    "src"
+    "src",
+    "src/index.d.ts"
   ],
   "scripts": {
     "clean": "rm -rf node_modules",

--- a/packages/npm/src/index.d.ts
+++ b/packages/npm/src/index.d.ts
@@ -1,0 +1,22 @@
+import type { MqlOptions } from '@microlink/mql'
+
+export interface CardsOutput {
+  path: string
+  filename: (query: string) => string
+  incremental?: boolean
+}
+
+export interface CardsOptions {
+  mqlOpts?: MqlOptions
+  entries?: string[]
+  output: CardsOutput
+  concurrency?: number
+}
+
+export interface CardsResult extends Array<string> {
+  [index: number]: string
+}
+
+declare function cards(options?: CardsOptions): Promise<CardsResult>
+
+export default cards


### PR DESCRIPTION
Adds TypeScript type definitions for @microlink/cards, including:
- CardsOutput interface for output configuration (path, filename, incremental)
- CardsOptions interface for function options (mqlOpts, entries, output, concurrency)
- CardsResult interface for the returned array of file paths

The types follow the existing pattern in the microlink ecosystem.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*