### PR TITLE
feat(types): add TypeScript type definitions

### DIFF
--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://github.com/microlinkhq/cards/tree/master/packages/npm",
   "version": "1.13.81",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "author": {
     "email": "hello@microlink.io",
     "name": "microlink.io",

--- a/packages/npm/src/index.d.ts
+++ b/packages/npm/src/index.d.ts
@@ -1,0 +1,74 @@
+import mql from '@microlink/mql'
+
+export interface MicrolinkCardsOptions {
+  /**
+   * Options passed to the Microlink Query Language (MQL) API.
+   * See: https://microlink.io/api
+   */
+  mqlOpts?: mql.MqlOptions
+  /**
+   * Array of entries to generate cards for.
+   * Each entry can be an object with properties like preset, title, etc.
+   * or a string URL.
+   */
+  entries?: Record<string, unknown>[]
+  /**
+   * Output configuration for generated cards.
+   */
+  output: {
+    /**
+     * Function to generate filename from each entry.
+     * Receives the entry object and should return a string.
+     */
+    filename: (entry: Record<string, unknown>) => string
+    /**
+     * The output directory where cards will be written.
+     */
+    path: string
+    /**
+     * If true, skip generating cards that already exist.
+     * @default true
+     */
+    incremental?: boolean
+  }
+  /**
+   * Number of cards to generate concurrently.
+   * @default 2
+   */
+  concurrency?: number
+}
+
+/**
+ * Generate Microlink Cards on build time.
+ *
+ * @example
+ * ```js
+ * const microlinkCards = require('@microlink/cards')
+ * const slugify = require('@sindresorhus/slugify')
+ *
+ * const build = async () =>
+ *   microlinkCards({
+ *     entries: [
+ *       {
+ *         preset: 'rauchg',
+ *         title: 'hello world'
+ *       }
+ *     ],
+ *     mqlOpts: {
+ *       apiKey: process.env.MICROLINK_API_KEY
+ *     },
+ *     output: {
+ *       filename: ({ title }) => slugify(title),
+ *       path: 'dist/images/cards',
+ *       incremental: true
+ *     }
+ *   })
+ *
+ * build()
+ *   .then(outputFiles => console.log(outputFiles))
+ *   .catch(error => console.error(error) || process.exit(1))
+ * ```
+ */
+export default function microlinkCards(
+  options: MicrolinkCardsOptions
+): Promise<string[]>


### PR DESCRIPTION
## Summary

Adds TypeScript type definitions for @microlink/cards package.

## Changes

- Added `src/index.d.ts` with full type definitions for the microlinkCards function
- Added `types` field to package.json pointing to the new type definition file

## Motivation

This package previously had no TypeScript type definitions, making it difficult for TypeScript users to use @microlink/cards in their projects. These types provide full type safety and IDE autocompletion.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*